### PR TITLE
[platforms] add axplat-loongarch64-qemu-virt and axplat-riscv64-qemu-virt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         rust-toolchain: [nightly]
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none]
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, loongarch64-unknown-none]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
@@ -59,6 +59,8 @@ jobs:
             target: aarch64-unknown-none
           - name: axplat-riscv64-qemu-virt
             target: riscv64gc-unknown-none-elf
+          - name: axplat-loongarch64-qemu-virt
+            target: loongarch64-unknown-none
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
             target: aarch64-unknown-none
           - name: axplat-aarch64-raspi
             target: aarch64-unknown-none
+          - name: axplat-riscv64-qemu-virt
+            target: riscv64gc-unknown-none-elf
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,35 +28,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -118,7 +119,7 @@ dependencies = [
 [[package]]
 name = "axcpu"
 version = "0.1.0"
-source = "git+https://github.com/arceos-org/axcpu.git#506f64dc092de98ef370542efb55b2002d6b336b"
+source = "git+https://github.com/arceos-org/axcpu.git#ff0ac8a69d721b1da1c4f0a8d3dd0d88bfa1512d"
 dependencies = [
  "aarch64-cpu",
  "cfg-if",
@@ -142,7 +143,7 @@ name = "axplat"
 version = "0.1.0"
 dependencies = [
  "axplat-macros",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "crate_interface",
  "handler_table",
  "memory_addr",
@@ -202,6 +203,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "axplat-loongarch64-qemu-virt"
+version = "0.1.0"
+dependencies = [
+ "axconfig-gen-macros",
+ "axcpu",
+ "axplat",
+ "kspin",
+ "lazyinit",
+ "log",
+ "loongArch64",
+ "memory_addr",
+ "ns16550a",
+ "page_table_entry",
+]
+
+[[package]]
 name = "axplat-macros"
 version = "0.1.0"
 dependencies = [
@@ -218,14 +235,8 @@ dependencies = [
  "axconfig-gen-macros",
  "axcpu",
  "axplat",
- "bitflags 2.6.0",
- "heapless",
- "int_ratio",
- "kspin",
- "lazyinit",
  "log",
  "memory_addr",
- "percpu",
  "riscv 0.13.0",
  "riscv_goldfish",
  "sbi-rt",
@@ -238,7 +249,7 @@ dependencies = [
  "axconfig-gen-macros",
  "axcpu",
  "axplat",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "heapless",
  "int_ratio",
  "kspin",
@@ -275,9 +286,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "byteorder"
@@ -293,18 +304,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -312,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -324,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -342,15 +353,15 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "crate_interface"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af24c4862260a825484470f5526a91ad1031e04ab899be62478241231f62b46"
+checksum = "70272a03a2cef15589bac05d3d15c023752f5f8f2da8be977d983a9d9e6250fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -371,9 +382,9 @@ checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "handler_table"
@@ -392,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heapless"
@@ -414,9 +425,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -462,18 +473,18 @@ checksum = "3861aac8febbb038673bf945ee47ac67940ca741b94d1bb3ff6066af2a181338"
 
 [[package]]
 name = "linkme"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566336154b9e58a4f055f6dd4cbab62c7dc0826ce3c0a04e63b2d2ecd784cdae"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbe595006d355eaf9ae11db92707d4338cd2384d16866131cc1afdbdd35d8d9"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -482,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -498,12 +509,12 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "loongArch64"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd48200d465466664e4e899b204b77b5447d60b1ababdad3a2c49ae85417b552"
+checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
 dependencies = [
  "bit_field",
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -514,9 +525,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memory_addr"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f769efcf10b9dfb4c913bebb409cda77b1a3f072b249bf5465e250bcb30eb49"
+checksum = "5438b8df0f13e16e1f46140de247695a95952a5a4479e47197a8711bf1063373"
 
 [[package]]
 name = "multiboot"
@@ -528,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ns16550a"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3cd8abe9e54bce27659507b94f355c9334378ab15da332b6986b3583ebf7228"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,22 +554,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "page_table_entry"
-version = "0.5.1"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "937b855b31ff3fa1274a5a4dfc1e57f124d26321adfa80ba03cdcc65921e8718"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "page_table_entry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c097d641745a066856a26eed6e486d4430bb3e32c94f1203ea09c63239b360a0"
 dependencies = [
  "aarch64-cpu",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "memory_addr",
  "x86_64 0.15.2",
 ]
 
 [[package]]
 name = "page_table_multiarch"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a26475e53be3cb87fcf9decd20e871bb78d7c4ba12fb03de79683d21ff3dad"
+checksum = "4647889585d29762d747be0916d6d28db72967a697d142be86f187a6b496832a"
 dependencies = [
  "log",
  "memory_addr",
@@ -592,18 +615,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -623,7 +646,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -676,9 +699,9 @@ checksum = "07aac72f95e774476db82916d79f2d303191310393830573c1ab5c821b21660a"
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "sbi-rt"
@@ -730,9 +753,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -753,20 +776,27 @@ checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "uart_16550"
@@ -774,16 +804,16 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "rustversion",
  "x86",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"
@@ -872,9 +902,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -910,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
 dependencies = [
  "bit_field",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "rustversion",
  "volatile",
 ]
@@ -922,7 +952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "rustversion",
  "volatile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "axplat-riscv64-qemu-virt"
+version = "0.1.0"
+dependencies = [
+ "axconfig-gen-macros",
+ "axcpu",
+ "axplat",
+ "bitflags 2.6.0",
+ "heapless",
+ "int_ratio",
+ "kspin",
+ "lazyinit",
+ "log",
+ "memory_addr",
+ "percpu",
+ "riscv 0.13.0",
+ "riscv_goldfish",
+ "sbi-rt",
+]
+
+[[package]]
 name = "axplat-x86-pc"
 version = "0.1.0"
 dependencies = [
@@ -649,10 +669,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
+name = "riscv_goldfish"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aac72f95e774476db82916d79f2d303191310393830573c1ab5c821b21660a"
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "sbi-rt"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbaa69be1eedc61c426e6d489b2260482e928b465360576900d52d496a58bd0"
+dependencies = [
+ "sbi-spec",
+]
+
+[[package]]
+name = "sbi-spec"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "platforms/axplat-aarch64-qemu-virt",
     "platforms/axplat-aarch64-raspi",
     "platforms/axplat-riscv64-qemu-virt",
+    "platforms/axplat-loongarch64-qemu-virt",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "platforms/axplat-aarch64-common",
     "platforms/axplat-aarch64-qemu-virt",
     "platforms/axplat-aarch64-raspi",
+    "platforms/axplat-riscv64-qemu-virt",
 ]
 
 [workspace.package]

--- a/platforms/axplat-aarch64-qemu-virt/src/boot.rs
+++ b/platforms/axplat-aarch64-qemu-virt/src/boot.rs
@@ -12,20 +12,22 @@ static mut BOOT_PT_L0: [A64PTE; 512] = [A64PTE::empty(); 512];
 static mut BOOT_PT_L1: [A64PTE; 512] = [A64PTE::empty(); 512];
 
 unsafe fn init_boot_page_table() {
-    // 0x0000_0000_0000 ~ 0x0080_0000_0000, table
-    BOOT_PT_L0[0] = A64PTE::new_table(pa!(&raw mut BOOT_PT_L1 as usize));
-    // 0x0000_0000_0000..0x0000_4000_0000, 1G block, device memory
-    BOOT_PT_L1[0] = A64PTE::new_page(
-        pa!(0),
-        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
-        true,
-    );
-    // 0x0000_4000_0000..0x0000_8000_0000, 1G block, normal memory
-    BOOT_PT_L1[1] = A64PTE::new_page(
-        pa!(0x4000_0000),
-        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
-        true,
-    );
+    unsafe {
+        // 0x0000_0000_0000 ~ 0x0080_0000_0000, table
+        BOOT_PT_L0[0] = A64PTE::new_table(pa!(&raw mut BOOT_PT_L1 as usize));
+        // 0x0000_0000_0000..0x0000_4000_0000, 1G block, device memory
+        BOOT_PT_L1[0] = A64PTE::new_page(
+            pa!(0),
+            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
+            true,
+        );
+        // 0x0000_4000_0000..0x0000_8000_0000, 1G block, normal memory
+        BOOT_PT_L1[1] = A64PTE::new_page(
+            pa!(0x4000_0000),
+            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
+            true,
+        );
+    }
 }
 
 unsafe fn enable_fp() {

--- a/platforms/axplat-loongarch64-qemu-virt/Cargo.toml
+++ b/platforms/axplat-loongarch64-qemu-virt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "axplat-riscv64-qemu-virt"
+name = "axplat-loongarch64-qemu-virt"
 version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
@@ -11,15 +11,17 @@ repository.workspace = true
 [features]
 fp_simd = ["axcpu/fp_simd"]
 irq = []
-rtc = ["riscv_goldfish"]
+rtc = []
 smp = []
 
 [dependencies]
+kspin = "0.1"
 log = "=0.4.21"
+lazyinit = "0.2"
 memory_addr = "0.3"
-riscv = "0.13"
-sbi-rt = { version = "0.0.3", features = ["legacy"] }
-riscv_goldfish = { version = "0.1", optional = true }
+loongArch64 = "0.2.4"
+ns16550a = "0.5.0"
+page_table_entry = "0.5"
 
 axconfig-gen-macros = { version = "0.1", features = ["nightly"] }
 axcpu = { workspace = true }

--- a/platforms/axplat-loongarch64-qemu-virt/axconfig.toml
+++ b/platforms/axplat-loongarch64-qemu-virt/axconfig.toml
@@ -1,0 +1,81 @@
+# Architecture identifier.
+arch = "loongarch64"
+# Platform identifier.
+platform = "loongarch64-qemu-virt"
+
+#
+# Platform configs
+#
+[plat]
+# Platform family.
+family = "loongarch64-qemu-virt"
+
+# Base address of the whole physical memory.
+phys-memory-base = 0x8000_0000        # uint
+# Size of the whole physical memory. (128M)
+phys-memory-size = 0x800_0000         # uint
+# Base physical address of the kernel image.
+kernel-base-paddr = 0x8000_0000       # uint
+
+# Base virtual address of the kernel image.
+kernel-base-vaddr = "0xffff_0000_8000_0000"     # uint
+# Linear mapping offset, for quick conversions between physical and virtual
+# addresses.
+phys-virt-offset = "0xffff_0000_0000_0000"      # uint
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = 0                             # uint
+# Kernel address space base.
+kernel-aspace-base = "0xffff_0000_0000_0000"    # uint
+# Kernel address space size.
+kernel-aspace-size = "0x0000_ffff_ffff_f000"    # uint
+# Stack size on bootstrapping. (256K)
+boot-stack-size = 0x40000                       # uint
+
+#
+# Device specifications
+#
+[devices]
+# MMIO ranges with format (`base_paddr`, `size`).
+mmio-ranges = [
+    [0x100E_0000, 0x0000_1000],         # GED
+    [0x1FE0_0000, 0x0000_1000],         # UART
+    [0x2000_0000, 0x1000_0000],         # PCI
+    [0x4000_0000, 0x0002_0000],         # PCI RANGES
+]           # [(uint, uint)]
+# VirtIO MMIO ranges with format (`base_paddr`, `size`).
+virtio-mmio-ranges = []    # [(uint, uint)]
+# Base physical address of the PCIe ECAM space.
+pci-ecam-base = 0x2000_0000             # uint
+# End PCI bus number.
+pci-bus-end = 0x7f                      # uint
+# PCI device memory ranges.
+pci-ranges = [
+    [0, 0],
+    [0x4000_0000, 0x0002_0000]
+]                                       # [(uint, uint)]
+# poweroff {
+#     value = <0x00000034>;
+#     offset = <0x00000000>;
+#     compatible = "syscon-poweroff";
+# };
+# ged@100e001c {
+#     reg-io-width = <0x00000001>;
+#     reg-shift = <0x00000000>;
+#     reg = <0x00000000 0x100e001c 0x00000000 0x00000003>;
+#     compatible = "syscon";
+# };
+ged-paddr  = 0x100E001C                 # uint
+# serial@1fe001e0 {
+#     interrupt-parent = <0x00008003>;
+#     interrupts = <0x00000002 0x00000004>;
+#     clock-frequency = <0x05f5e100>;
+#     reg = <0x00000000 0x1fe001e0 0x00000000 0x00000100>;
+#     compatible = "ns16550a";
+# };
+uart-paddr = 0x1FE001E0                 # uint
+
+# Timer interrupt frequency in Hz.
+timer-frequency = 100_000_000           # uint
+# Timer interrupt number.
+timer-irq = 11                          # uint

--- a/platforms/axplat-loongarch64-qemu-virt/src/boot.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/boot.rs
@@ -1,0 +1,117 @@
+use crate::config::plat::{BOOT_STACK_SIZE, PHYS_VIRT_OFFSET};
+use page_table_entry::{loongarch64::LA64PTE, GenericPTE, MappingFlags};
+
+#[unsafe(link_section = ".bss.stack")]
+static mut BOOT_STACK: [u8; BOOT_STACK_SIZE] = [0; BOOT_STACK_SIZE];
+
+#[unsafe(link_section = ".data.boot_page_table")]
+static mut BOOT_PT_L0: [LA64PTE; 512] = [LA64PTE::empty(); 512];
+
+#[unsafe(link_section = ".data.boot_page_table")]
+static mut BOOT_PT_L1: [LA64PTE; 512] = [LA64PTE::empty(); 512];
+
+unsafe fn init_boot_page_table() {
+    unsafe {
+        let l1_va = va!(&raw const BOOT_PT_L1 as usize);
+        // 0x0000_0000_0000 ~ 0x0080_0000_0000, table
+        BOOT_PT_L0[0] = LA64PTE::new_table(crate::mem::virt_to_phys(l1_va));
+        // 0x0000_0000..0x4000_0000, VPWXGD, 1G block
+        BOOT_PT_L1[0] = LA64PTE::new_page(
+            pa!(0),
+            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
+            true,
+        );
+        // 0x8000_0000..0xc000_0000, VPWXGD, 1G block
+        BOOT_PT_L1[2] = LA64PTE::new_page(
+            pa!(0x8000_0000),
+            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
+            true,
+        );
+    }
+}
+
+fn enable_fp_simd() {
+    // FP/SIMD needs to be enabled early, as the compiler may generate SIMD
+    // instructions in the bootstrapping code to speed up the operations
+    // like `memset` and `memcpy`.
+    #[cfg(feature = "fp_simd")]
+    {
+        axcpu::asm::enable_fp();
+        axcpu::asm::enable_lsx();
+    }
+}
+
+fn init_mmu() {
+    axcpu::init::init_mmu(
+        crate::mem::virt_to_phys(va!(&raw const BOOT_PT_L0 as usize)),
+        PHYS_VIRT_OFFSET,
+    );
+}
+
+/// The earliest entry point for the primary CPU.
+///
+/// We can't use bl to jump to higher address, so we use jirl to jump to higher address.
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = ".text.boot")]
+unsafe extern "C" fn _start() -> ! {
+    core::arch::naked_asm!("
+        ori         $t0, $zero, 0x1     # CSR_DMW1_PLV0
+        lu52i.d     $t0, $t0, -2048     # UC, PLV0, 0x8000 xxxx xxxx xxxx
+        csrwr       $t0, 0x180          # LOONGARCH_CSR_DMWIN0
+        ori         $t0, $zero, 0x11    # CSR_DMW1_MAT | CSR_DMW1_PLV0
+        lu52i.d     $t0, $t0, -1792     # CA, PLV0, 0x9000 xxxx xxxx xxxx
+        csrwr       $t0, 0x181          # LOONGARCH_CSR_DMWIN1
+
+        # Setup Stack
+        la.global   $sp, {boot_stack}
+        li.d        $t0, {boot_stack_size}
+        add.d       $sp, $sp, $t0       # setup boot stack
+
+        # Init MMU
+        bl          {enable_fp_simd}    # enable FP/SIMD instructions
+        bl          {init_boot_page_table}
+        bl          {init_mmu}          # setup boot page table and enable MMU
+
+        csrrd       $a0, 0x20           # cpuid
+        li.d        $a1, 0              # TODO: parse dtb
+        la.global   $t0, {entry}
+        jirl        $zero, $t0, 0",
+        boot_stack_size = const BOOT_STACK_SIZE,
+        boot_stack = sym BOOT_STACK,
+        enable_fp_simd = sym enable_fp_simd,
+        init_boot_page_table = sym init_boot_page_table,
+        init_mmu = sym init_mmu,
+        entry = sym axplat::call_main,
+    )
+}
+
+/// The earliest entry point for secondary CPUs.
+#[cfg(feature = "smp")]
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = ".text.boot")]
+unsafe extern "C" fn _start_secondary() -> ! {
+    core::arch::naked_asm!("
+        ori          $t0, $zero, 0x1     # CSR_DMW1_PLV0
+        lu52i.d      $t0, $t0, -2048     # UC, PLV0, 0x8000 xxxx xxxx xxxx
+        csrwr        $t0, 0x180          # LOONGARCH_CSR_DMWIN0
+        ori          $t0, $zero, 0x11    # CSR_DMW1_MAT | CSR_DMW1_PLV0
+        lu52i.d      $t0, $t0, -1792     # CA, PLV0, 0x9000 xxxx xxxx xxxx
+        csrwr        $t0, 0x181          # LOONGARCH_CSR_DMWIN1
+        la.abs       $t0, {sm_boot_stack_top}
+        ld.d         $sp, $t0,0          # read boot stack top
+
+        # Init MMU
+        bl           {enable_fp_simd}    # enable FP/SIMD instructions
+        bl           {init_mmu}          # setup boot page table and enable MMU
+
+        csrrd        $a0, 0x20                  # cpuid
+        la.global    $t0, {entry}
+        jirl         $zero, $t0, 0",
+        sm_boot_stack_top = sym super::mp::SMP_BOOT_STACK_TOP,
+        enable_fp_simd = sym enable_fp_simd,
+        init_mmu = sym init_mmu,
+        entry = sym axplat::call_secondary_main,
+    )
+}

--- a/platforms/axplat-loongarch64-qemu-virt/src/console.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/console.rs
@@ -1,0 +1,43 @@
+use crate::mem::phys_to_virt;
+use kspin::SpinNoIrq;
+use memory_addr::PhysAddr;
+use ns16550a::Uart;
+
+const UART_BASE: PhysAddr = pa!(crate::config::devices::UART_PADDR);
+
+static UART: SpinNoIrq<Uart> = SpinNoIrq::new(Uart::new(phys_to_virt(UART_BASE).as_usize()));
+
+use axplat::console::ConsoleIf;
+
+struct ConsoleIfImpl;
+
+#[impl_plat_interface]
+impl ConsoleIf for ConsoleIfImpl {
+    /// Writes bytes to the console from input u8 slice.
+    fn write_bytes(bytes: &[u8]) {
+        for &c in bytes {
+            let uart = UART.lock();
+            match c {
+                b'\n' => {
+                    let _ = uart.put(b'\r');
+                    let _ = uart.put(b'\n');
+                }
+                c => {
+                    let _ = uart.put(c);
+                }
+            }
+        }
+    }
+
+    /// Reads bytes from the console into the given mutable slice.
+    /// Returns the number of bytes read.
+    fn read_bytes(bytes: &mut [u8]) -> usize {
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            match UART.lock().get() {
+                Some(c) => *byte = c,
+                None => return i,
+            }
+        }
+        bytes.len()
+    }
+}

--- a/platforms/axplat-loongarch64-qemu-virt/src/init.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/init.rs
@@ -1,0 +1,36 @@
+use axplat::init::InitIf;
+
+struct InitIfImpl;
+
+#[impl_plat_interface]
+impl InitIf for InitIfImpl {
+    /// This function should be called immediately after the kernel has booted,
+    /// and performed earliest platform configuration and initialization (e.g.,
+    /// early console, clocking).
+    fn init_early(cpu_id: usize, _mbi: usize) {
+        axcpu::init::init_cpu(cpu_id);
+        crate::time::init_early();
+    }
+
+    /// Initializes the platform at the early stage for secondary cores.
+    fn init_early_secondary(cpu_id: usize) {
+        axcpu::init::init_cpu(cpu_id);
+    }
+
+    /// Initializes the platform at the later stage for the primary core.
+    ///
+    /// This function should be called after the kernel has done part of its
+    /// initialization (e.g, logging, memory management), and finalized the rest of
+    /// platform configuration and initialization.
+    fn init_later(_cpu_id: usize, _arg: usize) {
+        crate::time::init_percpu();
+    }
+
+    /// Initializes the platform at the later stage for secondary cores.
+    fn init_later_secondary(_cpu_id: usize) {
+        #[cfg(feature = "smp")]
+        {
+            crate::time::init_percpu();
+        }
+    }
+}

--- a/platforms/axplat-loongarch64-qemu-virt/src/irq.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/irq.rs
@@ -1,0 +1,61 @@
+use axplat::irq::{HandlerTable, IrqHandler, IrqIf};
+use loongArch64::register::{
+    ecfg::{self, LineBasedInterrupt},
+    ticlr,
+};
+
+/// The maximum number of IRQs.
+pub const MAX_IRQ_COUNT: usize = 12;
+
+static IRQ_HANDLER_TABLE: HandlerTable<MAX_IRQ_COUNT> = HandlerTable::new();
+
+struct IrqIfImpl;
+
+#[impl_plat_interface]
+impl IrqIf for IrqIfImpl {
+    /// Enables or disables the given IRQ.
+    fn set_enable(irq_num: usize, enabled: bool) {
+        if irq_num == crate::config::devices::TIMER_IRQ {
+            let old_value = ecfg::read().lie();
+            let new_value = match enabled {
+                true => old_value | LineBasedInterrupt::TIMER,
+                false => old_value & !LineBasedInterrupt::TIMER,
+            };
+            ecfg::set_lie(new_value);
+        }
+    }
+
+    /// Registers an IRQ handler for the given IRQ.
+    fn register(irq_num: usize, handler: IrqHandler) -> bool {
+        if IRQ_HANDLER_TABLE.register_handler(irq_num, handler) {
+            Self::set_enable(irq_num, true);
+            return true;
+        }
+        warn!("register handler for IRQ {} failed", irq_num);
+        false
+    }
+
+    /// Unregisters the IRQ handler for the given IRQ.
+    ///
+    /// It also disables the IRQ if the unregistration succeeds. It returns the
+    /// existing handler if it is registered, `None` otherwise.
+    fn unregister(irq: usize) -> Option<IrqHandler> {
+        Self::set_enable(irq, false);
+        IRQ_HANDLER_TABLE.unregister_handler(irq)
+    }
+
+    /// Handles the IRQ.
+    ///
+    /// It is called by the common interrupt handler. It should look up in the
+    /// IRQ handler table and calls the corresponding handler. If necessary, it
+    /// also acknowledges the interrupt controller after handling.
+    fn handle(irq: usize) {
+        if irq == crate::config::devices::TIMER_IRQ {
+            ticlr::clear_timer_interrupt();
+        }
+        trace!("IRQ {}", irq);
+        if !IRQ_HANDLER_TABLE.handle(irq) {
+            warn!("Unhandled IRQ {}", irq);
+        }
+    }
+}

--- a/platforms/axplat-loongarch64-qemu-virt/src/lib.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/lib.rs
@@ -7,15 +7,17 @@ extern crate axplat;
 #[macro_use]
 extern crate memory_addr;
 
+mod config {
+    axconfig_gen_macros::include_configs!("axconfig.toml");
+}
+
 mod boot;
 mod console;
 mod init;
 #[cfg(feature = "irq")]
 mod irq;
 mod mem;
+#[cfg(feature = "smp")]
+mod mp;
 mod power;
 mod time;
-
-mod config {
-    axconfig_gen_macros::include_configs!("axconfig.toml");
-}

--- a/platforms/axplat-loongarch64-qemu-virt/src/mem.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/mem.rs
@@ -1,0 +1,44 @@
+use axplat::mem::{MemIf, RawRange};
+use memory_addr::{PhysAddr, VirtAddr};
+
+use crate::config::devices::MMIO_RANGES;
+use crate::config::plat::{PHYS_MEMORY_BASE, PHYS_MEMORY_SIZE, PHYS_VIRT_OFFSET};
+
+struct MemIfImpl;
+
+#[allow(dead_code)]
+pub const fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+    va!(paddr.as_usize() + PHYS_VIRT_OFFSET)
+}
+
+#[allow(dead_code)]
+pub const fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+    pa!(vaddr.as_usize() - PHYS_VIRT_OFFSET)
+}
+
+#[impl_plat_interface]
+impl MemIf for MemIfImpl {
+    /// Returns all physical memory (RAM) ranges on the platform.
+    ///
+    /// All memory ranges except reserved ranges (including the kernel loaded
+    /// range) are free for allocation.
+    fn phys_ram_ranges() -> &'static [RawRange] {
+        &[(PHYS_MEMORY_BASE, PHYS_MEMORY_SIZE)]
+    }
+
+    /// Returns all reserved physical memory ranges on the platform.
+    ///
+    /// Reserved memory can be contained in [`phys_ram_ranges`], they are not
+    /// allocatable but should be mapped to kernel's address space.
+    ///
+    /// Note that the ranges returned should not include the range where the
+    /// kernel is loaded.
+    fn reserved_phys_ram_ranges() -> &'static [RawRange] {
+        &[]
+    }
+
+    /// Returns all device memory (MMIO) ranges on the platform.
+    fn mmio_ranges() -> &'static [RawRange] {
+        &MMIO_RANGES
+    }
+}

--- a/platforms/axplat-loongarch64-qemu-virt/src/mp.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/mp.rs
@@ -1,0 +1,21 @@
+use loongArch64::ipi::{csr_mail_send, send_ipi_single};
+use memory_addr::PhysAddr;
+
+use crate::mem::phys_to_virt;
+
+const ACTION_BOOT_CPU: u32 = 1;
+
+pub static mut SMP_BOOT_STACK_TOP: usize = 0;
+
+/// Starts the given secondary CPU with its boot stack.
+pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
+    unsafe extern "C" {
+        fn _start_secondary();
+    }
+    let stack_top_virt_addr = phys_to_virt(stack_top).as_usize();
+    unsafe {
+        SMP_BOOT_STACK_TOP = stack_top_virt_addr;
+    }
+    csr_mail_send(_start_secondary as usize as _, cpu_id, 0);
+    send_ipi_single(cpu_id, ACTION_BOOT_CPU);
+}

--- a/platforms/axplat-loongarch64-qemu-virt/src/power.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/power.rs
@@ -1,0 +1,30 @@
+use axplat::power::PowerIf;
+
+struct PowerImpl;
+
+#[impl_plat_interface]
+impl PowerIf for PowerImpl {
+    /// Bootstraps the given CPU core with the given initial stack (in physical
+    /// address).
+    ///
+    /// Where `cpu_id` is the logical CPU ID (0, 1, ..., N-1, N is the number of
+    /// CPU cores on the platform).
+    fn cpu_boot(_cpu_id: usize, _stack_top_paddr: usize) {
+        #[cfg(feature = "smp")]
+        crate::mp::start_secondary_cpu(_cpu_id, pa!(_stack_top_paddr));
+    }
+
+    /// Shutdown the whole system.
+    fn system_off() -> ! {
+        const HALT_ADDR: *mut u8 =
+            crate::mem::phys_to_virt(pa!(crate::config::devices::GED_PADDR)).as_mut_ptr();
+
+        info!("Shutting down...");
+        unsafe { HALT_ADDR.write_volatile(0x34) };
+        axcpu::asm::halt();
+        warn!("It should shutdown!");
+        loop {
+            axcpu::asm::halt();
+        }
+    }
+}

--- a/platforms/axplat-loongarch64-qemu-virt/src/time.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/time.rs
@@ -1,0 +1,67 @@
+use axplat::time::TimeIf;
+use lazyinit::LazyInit;
+use loongArch64::time::Time;
+
+static NANOS_PER_TICK: LazyInit<u64> = LazyInit::new();
+
+/// RTC wall time offset in nanoseconds at monotonic time base.
+static mut RTC_EPOCHOFFSET_NANOS: u64 = 0;
+
+pub(super) fn init_percpu() {
+    #[cfg(feature = "irq")]
+    {
+        use loongArch64::register::tcfg;
+        tcfg::set_init_val(0);
+        tcfg::set_periodic(false);
+        tcfg::set_en(true);
+        axplat::irq::set_enable(crate::config::devices::TIMER_IRQ, true);
+    }
+}
+
+pub(super) fn init_early() {
+    NANOS_PER_TICK
+        .init_once(axplat::time::NANOS_PER_SEC / loongArch64::time::get_timer_freq() as u64);
+}
+
+struct TimeIfImpl;
+
+#[impl_plat_interface]
+impl TimeIf for TimeIfImpl {
+    /// Returns the current clock time in hardware ticks.
+    fn current_ticks() -> u64 {
+        Time::read() as _
+    }
+
+    /// Return epoch offset in nanoseconds (wall time offset to monotonic clock start).
+    fn epochoffset_nanos() -> u64 {
+        unsafe { RTC_EPOCHOFFSET_NANOS }
+    }
+
+    /// Converts hardware ticks to nanoseconds.
+    fn ticks_to_nanos(ticks: u64) -> u64 {
+        ticks * *NANOS_PER_TICK
+    }
+
+    /// Converts nanoseconds to hardware ticks.
+    fn nanos_to_ticks(nanos: u64) -> u64 {
+        nanos / *NANOS_PER_TICK
+    }
+
+    /// Set a one-shot timer.
+    ///
+    /// A timer interrupt will be triggered at the specified monotonic time deadline (in nanoseconds).
+    ///
+    /// LoongArch64 TCFG CSR: <https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#timer-configuration>
+    fn set_oneshot_timer(_deadline_ns: u64) {
+        #[cfg(feature = "irq")]
+        {
+            use loongArch64::register::tcfg;
+
+            let ticks_now = Self::current_ticks();
+            let ticks_deadline = Self::nanos_to_ticks(_deadline_ns);
+            let init_value = ticks_deadline - ticks_now;
+            tcfg::set_init_val(init_value as _);
+            tcfg::set_en(true);
+        }
+    }
+}

--- a/platforms/axplat-riscv64-qemu-virt/Cargo.toml
+++ b/platforms/axplat-riscv64-qemu-virt/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "axplat-riscv64-qemu-virt"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+repository.workspace = true
+
+[features]
+fp_simd = ["axcpu/fp_simd"]
+irq = []
+rtc = ["riscv_goldfish"]
+smp = []
+
+[dependencies]
+kspin = "0.1"
+log = "=0.4.21"
+bitflags = "2.6"
+lazyinit = "0.2"
+int_ratio = "0.1"
+percpu = "0.2"
+memory_addr = "0.3"
+heapless = "0.8"
+axconfig-gen-macros = { version = "0.1", features = ["nightly"] }
+axcpu = { workspace = true }
+axplat = { workspace = true }
+
+riscv = "0.13"
+sbi-rt = { version = "0.0.3", features = ["legacy"] }
+riscv_goldfish = { version = "0.1", optional = true }

--- a/platforms/axplat-riscv64-qemu-virt/axconfig.toml
+++ b/platforms/axplat-riscv64-qemu-virt/axconfig.toml
@@ -1,0 +1,81 @@
+# Architecture identifier.
+arch = "riscv64"                    # str
+# Platform identifier.
+platform = "riscv64-qemu-virt"      # str
+
+#
+# Platform configs
+#
+[plat]
+# Platform family.
+family = "riscv64-qemu-virt"        # str
+
+# Base address of the whole physical memory.
+phys-memory-base = 0x8000_0000      # uint
+# Size of the whole physical memory. (128M)
+phys-memory-size = 0x800_0000       # uint
+# Base physical address of the kernel image.
+kernel-base-paddr = 0x8020_0000     # uint
+# Base virtual address of the kernel image.
+kernel-base-vaddr = "0xffff_ffc0_8020_0000"     # uint
+# Linear mapping offset, for quick conversions between physical and virtual
+# addresses.
+phys-virt-offset = "0xffff_ffc0_0000_0000"      # uint
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = 0                             # uint
+# Kernel address space base.
+kernel-aspace-base = "0xffff_ffc0_0000_0000"    # uint
+# Kernel address space size.
+kernel-aspace-size = "0x0000_003f_ffff_f000"    # uint
+# Stack size on bootstrapping. (256K)
+boot-stack-size = 0x40000                       # uint
+
+#
+# Device specifications
+#
+[devices]
+# MMIO ranges with format (`base_paddr`, `size`).
+mmio-ranges = [
+    [0x0010_1000, 0x1000],          # RTC
+    [0x0c00_0000, 0x21_0000],       # PLIC
+    [0x1000_0000, 0x1000],          # UART
+    [0x1000_1000, 0x8000],          # VirtIO
+    [0x3000_0000, 0x1000_0000],     # PCI config space
+    [0x4000_0000, 0x4000_0000],     # PCI memory ranges (ranges 1: 32-bit MMIO space)
+]                                   # [(uint, uint)]
+# VirtIO MMIO ranges with format (`base_paddr`, `size`).
+virtio-mmio-ranges = [
+    [0x1000_1000, 0x1000],
+    [0x1000_2000, 0x1000],
+    [0x1000_3000, 0x1000],
+    [0x1000_4000, 0x1000],
+    [0x1000_5000, 0x1000],
+    [0x1000_6000, 0x1000],
+    [0x1000_7000, 0x1000],
+    [0x1000_8000, 0x1000],
+] # [(uint, uint)]
+# Base physical address of the PCIe ECAM space.
+pci-ecam-base = 0x3000_0000 # uint
+# End PCI bus number (`bus-range` property in device tree).
+pci-bus-end = 0xff # uint
+# PCI device memory ranges (`ranges` property in device tree).
+pci-ranges = [
+    [0x0300_0000, 0x1_0000],        # PIO space
+    [0x4000_0000, 0x4000_0000],     # 32-bit MMIO space
+    [0x4_0000_0000, 0x4_0000_0000], # 64-bit MMIO space
+]                                   # [(uint, uint)]
+
+# Timer interrupt frequency in Hz.
+timer-frequency = 10_000_000        # uint
+# Timer interrupt num (PPI, physical).
+timer-irq = 0x05                    # uint
+
+# rtc@101000 {
+#     interrupts = <0x0b>;
+#     interrupt-parent = <0x03>;
+#     reg = <0x00 0x101000 0x00 0x1000>;
+#     compatible = "google,goldfish-rtc";
+# };
+# RTC (goldfish) Address
+rtc-paddr = 0x10_1000               # uint

--- a/platforms/axplat-riscv64-qemu-virt/axconfig.toml
+++ b/platforms/axplat-riscv64-qemu-virt/axconfig.toml
@@ -68,8 +68,8 @@ pci-ranges = [
 
 # Timer interrupt frequency in Hz.
 timer-frequency = 10_000_000        # uint
-# Timer interrupt num (PPI, physical).
-timer-irq = 0x05                    # uint
+# Timer interrupt num.
+timer-irq = "0x8000_0000_0000_0005" # uint
 
 # rtc@101000 {
 #     interrupts = <0x0b>;

--- a/platforms/axplat-riscv64-qemu-virt/src/boot.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/boot.rs
@@ -1,0 +1,96 @@
+use riscv::register::satp;
+
+use crate::config::plat::{BOOT_STACK_SIZE, PHYS_VIRT_OFFSET};
+
+#[unsafe(link_section = ".bss.stack")]
+static mut BOOT_STACK: [u8; BOOT_STACK_SIZE] = [0; BOOT_STACK_SIZE];
+
+#[unsafe(link_section = ".data.boot_page_table")]
+static mut BOOT_PT_SV39: [u64; 512] = [0; 512];
+
+#[allow(clippy::identity_op)] // (0x0 << 10) here makes sense because it's an address
+unsafe fn init_boot_page_table() {
+    unsafe {
+        // 0x0000_0000..0x4000_0000, VRWX_GAD, 1G block
+        BOOT_PT_SV39[0] = (0x0 << 10) | 0xef;
+        // 0x8000_0000..0xc000_0000, VRWX_GAD, 1G block
+        BOOT_PT_SV39[2] = (0x80000 << 10) | 0xef;
+        // 0xffff_ffc0_0000_0000..0xffff_ffc0_4000_0000, VRWX_GAD, 1G block
+        BOOT_PT_SV39[0x100] = (0x0 << 10) | 0xef;
+        // 0xffff_ffc0_8000_0000..0xffff_ffc0_c000_0000, VRWX_GAD, 1G block
+        BOOT_PT_SV39[0x102] = (0x80000 << 10) | 0xef;
+    }
+}
+
+unsafe fn init_mmu() {
+    let page_table_root = &raw const BOOT_PT_SV39 as usize;
+    unsafe {
+        satp::set(satp::Mode::Sv39, 0, page_table_root >> 12);
+    }
+    riscv::asm::sfence_vma_all();
+}
+
+/// The earliest entry point for the primary CPU.
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = ".text.boot")]
+unsafe extern "C" fn _start() -> ! {
+    // PC = 0x8020_0000
+    // a0 = hartid
+    // a1 = dtb
+    core::arch::naked_asm!("
+        mv      s0, a0                  // save hartid
+        mv      s1, a1                  // save DTB pointer
+        la      sp, {boot_stack}
+        li      t0, {boot_stack_size}
+        add     sp, sp, t0              // setup boot stack
+
+        call    {init_boot_page_table}
+        call    {init_mmu}              // setup boot page table and enabel MMU
+
+        li      s2, {phys_virt_offset}  // fix up virtual high address
+        add     sp, sp, s2
+
+        mv      a0, s0
+        mv      a1, s1
+        la      a2, {entry}
+        add     a2, a2, s2
+        jalr    a2                      // call rust_entry(hartid, dtb)
+        j       .",
+        phys_virt_offset = const PHYS_VIRT_OFFSET,
+        boot_stack_size = const BOOT_STACK_SIZE,
+        boot_stack = sym BOOT_STACK,
+        init_boot_page_table = sym init_boot_page_table,
+        init_mmu = sym init_mmu,
+        entry = sym super::rust_entry,
+    )
+}
+
+/// The earliest entry point for secondary CPUs.
+#[cfg(feature = "smp")]
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = ".text.boot")]
+unsafe extern "C" fn _start_secondary() -> ! {
+    // a0 = hartid
+    // a1 = SP
+    core::arch::naked_asm!("
+        mv      s0, a0                  // save hartid
+        mv      sp, a1                  // set SP
+
+        call    {init_mmu}              // setup boot page table and enabel MMU
+
+        li      s1, {phys_virt_offset}  // fix up virtual high address
+        add     a1, a1, s1
+        add     sp, sp, s1
+
+        mv      a0, s0
+        la      a1, {entry}
+        add     a1, a1, s1
+        jalr    a1                      // call rust_entry_secondary(hartid)
+        j       .",
+        phys_virt_offset = const PHYS_VIRT_OFFSET,
+        init_mmu = sym init_mmu,
+        entry = sym super::rust_entry_secondary,
+    )
+}

--- a/platforms/axplat-riscv64-qemu-virt/src/console.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/console.rs
@@ -1,0 +1,49 @@
+use memory_addr::VirtAddr;
+
+use crate::mem::virt_to_phys;
+
+/// The maximum number of bytes that can be read at once.
+const MAX_RW_SIZE: usize = 256;
+
+/// Tries to write bytes to the console from input u8 slice.
+/// Returns the number of bytes written.
+fn try_write_bytes(bytes: &[u8]) -> usize {
+    sbi_rt::console_write(sbi_rt::Physical::new(
+        // A maximum of 256 bytes can be written at a time
+        // to prevent SBI from disabling IRQs for too long.
+        bytes.len().min(MAX_RW_SIZE),
+        virt_to_phys(VirtAddr::from_ptr_of(bytes.as_ptr())).as_usize(),
+        0,
+    ))
+    .value
+}
+
+use axplat::console::ConsoleIf;
+
+struct ConsoleIfImpl;
+
+#[impl_plat_interface]
+impl ConsoleIf for ConsoleIfImpl {
+    /// Writes bytes to the console from input u8 slice.
+    fn write_bytes(bytes: &[u8]) {
+        let mut write_len = 0;
+        while write_len < bytes.len() {
+            let len = try_write_bytes(&bytes[write_len..]);
+            if len == 0 {
+                break;
+            }
+            write_len += len;
+        }
+    }
+
+    /// Reads bytes from the console into the given mutable slice.
+    /// Returns the number of bytes read.
+    fn read_bytes(bytes: &mut [u8]) -> usize {
+        sbi_rt::console_read(sbi_rt::Physical::new(
+            bytes.len().min(MAX_RW_SIZE),
+            virt_to_phys(VirtAddr::from_mut_ptr_of(bytes.as_mut_ptr())).as_usize(),
+            0,
+        ))
+        .value
+    }
+}

--- a/platforms/axplat-riscv64-qemu-virt/src/console.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/console.rs
@@ -27,12 +27,16 @@ impl ConsoleIf for ConsoleIfImpl {
     /// Writes bytes to the console from input u8 slice.
     fn write_bytes(bytes: &[u8]) {
         let mut write_len = 0;
+        let mut buf = [0; MAX_RW_SIZE];
         while write_len < bytes.len() {
-            let len = try_write_bytes(&bytes[write_len..]);
-            if len == 0 {
+            let n = buf.len().min(bytes.len() - write_len);
+            if n == 0 {
                 break;
             }
-            write_len += len;
+            // `bytes` can be from user space, copy it into a kernel buffer
+            // to correctly use `virt_to_phys`.
+            buf[..n].copy_from_slice(&bytes[write_len..write_len + n]);
+            write_len += try_write_bytes(&buf[..n]);
         }
     }
 

--- a/platforms/axplat-riscv64-qemu-virt/src/init.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/init.rs
@@ -1,0 +1,40 @@
+use axplat::init::InitIf;
+
+struct InitIfImpl;
+
+#[impl_plat_interface]
+impl InitIf for InitIfImpl {
+    /// This function should be called immediately after the kernel has booted,
+    /// and performed earliest platform configuration and initialization (e.g.,
+    /// early console, clocking).
+    fn init_early(cpu_id: usize, _mbi: usize) {
+        axcpu::init::init_cpu(cpu_id);
+        crate::time::init_early();
+    }
+
+    /// Initializes the platform at the early stage for secondary cores.
+    fn init_early_secondary(cpu_id: usize) {
+        axcpu::init::init_cpu(cpu_id);
+    }
+
+    /// Initializes the platform at the later stage for the primary core.
+    ///
+    /// This function should be called after the kernel has done part of its
+    /// initialization (e.g, logging, memory management), and finalized the rest of
+    /// platform configuration and initialization.
+    fn init_later(_cpu_id: usize, _arg: usize) {
+        #[cfg(feature = "irq")]
+        crate::irq::init_percpu();
+        crate::time::init_percpu();
+    }
+
+    /// Initializes the platform at the later stage for secondary cores.
+    fn init_later_secondary(_cpu_id: usize) {
+        #[cfg(feature = "smp")]
+        {
+            #[cfg(feature = "irq")]
+            crate::irq::init_percpu();
+            crate::time::init_percpu();
+        }
+    }
+}

--- a/platforms/axplat-riscv64-qemu-virt/src/irq.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/irq.rs
@@ -1,20 +1,23 @@
 //! TODO: PLIC
 
 use axplat::irq::{HandlerTable, IrqHandler, IrqIf};
-use lazyinit::LazyInit;
+use core::sync::atomic::{AtomicPtr, Ordering};
 use riscv::register::sie;
+
+/// `Interrupt` bit in `scause`
+pub(super) const INTC_IRQ_BASE: usize = 1 << (usize::BITS - 1);
 
 /// Supervisor software interrupt in `scause`
 #[allow(unused)]
-pub(super) const S_SOFT: usize = 1;
+pub(super) const S_SOFT: usize = INTC_IRQ_BASE + 1;
 
 /// Supervisor timer interrupt in `scause`
-pub(super) const S_TIMER: usize = 5;
+pub(super) const S_TIMER: usize = INTC_IRQ_BASE + 5;
 
 /// Supervisor external interrupt in `scause`
-pub(super) const S_EXT: usize = 9;
+pub(super) const S_EXT: usize = INTC_IRQ_BASE + 9;
 
-static TIMER_HANDLER: LazyInit<IrqHandler> = LazyInit::new();
+static TIMER_HANDLER: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
 
 /// The maximum number of IRQs.
 pub const MAX_IRQ_COUNT: usize = 1024;
@@ -22,11 +25,19 @@ pub const MAX_IRQ_COUNT: usize = 1024;
 static IRQ_HANDLER_TABLE: HandlerTable<MAX_IRQ_COUNT> = HandlerTable::new();
 
 macro_rules! with_cause {
-    ($cause: expr, @TIMER => $timer_op: expr, @EXT => $ext_op: expr $(,)?) => {
+    ($cause: expr, @S_TIMER => $timer_op: expr, @S_EXT => $ext_op: expr, @EX_IRQ => $plic_op: expr $(,)?) => {
         match $cause {
             S_TIMER => $timer_op,
             S_EXT => $ext_op,
-            _ => panic!("invalid trap cause: {:#x}", $cause),
+            other => {
+                if other & INTC_IRQ_BASE == 0 {
+                    // Device-side interrupts read from PLIC
+                    $plic_op
+                } else {
+                    // Other CPU-side interrupts
+                    panic!("Unknown IRQ cause: {}", other);
+                }
+            }
         }
     };
 }
@@ -46,30 +57,39 @@ struct IrqIfImpl;
 impl IrqIf for IrqIfImpl {
     /// Enables or disables the given IRQ.
     fn set_enable(irq: usize, _enabled: bool) {
-        if irq == S_EXT {
-            // TODO: set enable in PLIC
-        }
+        // TODO: set enable in PLIC
+        warn!("set_enable is not implemented for IRQ {}", irq);
     }
 
     /// Registers an IRQ handler for the given IRQ.
     ///
     /// It also enables the IRQ if the registration succeeds. It returns `false` if
     /// the registration failed.
+    ///
+    /// The `irq` parameter has the following semantics
+    /// 1. If its highest bit is 1, it means it is an interrupt on the CPU side. Its
+    /// value comes from `scause`, where [`S_SOFT`] represents software interrupt
+    /// and [`S_TIMER`] represents timer interrupt. If its value is [`S_EXT`], it
+    /// means it is an external interrupt, and the real IRQ number needs to
+    /// be obtained from PLIC.
+    /// 2. If its highest bit is 0, it means it is an interrupt on the device side,
+    /// and its value is equal to the IRQ number provided by PLIC.
     fn register(irq: usize, handler: IrqHandler) -> bool {
         with_cause!(
             irq,
-            @TIMER => if !TIMER_HANDLER.is_inited() {
-                TIMER_HANDLER.init_once(handler);
-                true
-            } else {
+            @S_TIMER => TIMER_HANDLER.compare_exchange(core::ptr::null_mut(), handler as *mut _, Ordering::AcqRel, Ordering::Acquire).is_ok(),
+            @S_EXT => {
+                warn!("External IRQ should be got from PLIC, not scause");
                 false
             },
-            @EXT => if IRQ_HANDLER_TABLE.register_handler(irq, handler) {
-                Self::set_enable(irq, true);
-                return true;
-            } else {
-                warn!("register handler for IRQ {} failed", irq);
-                false
+            @EX_IRQ => {
+                if IRQ_HANDLER_TABLE.register_handler(irq, handler) {
+                    Self::set_enable(irq, true);
+                    true
+                } else {
+                    warn!("register handler for External IRQ {} failed", irq);
+                    false
+                }
             }
         )
     }
@@ -79,8 +99,22 @@ impl IrqIf for IrqIfImpl {
     /// It also disables the IRQ if the unregistration succeeds. It returns the
     /// existing handler if it is registered, `None` otherwise.
     fn unregister(irq: usize) -> Option<IrqHandler> {
-        Self::set_enable(irq, false);
-        IRQ_HANDLER_TABLE.unregister_handler(irq)
+        with_cause!(
+            irq,
+            @S_TIMER => {
+                let handler = TIMER_HANDLER.swap(core::ptr::null_mut(), Ordering::AcqRel);
+                if !handler.is_null() {
+                    Some(unsafe { core::mem::transmute::<*mut (), IrqHandler>(handler) })
+                } else {
+                    None
+                }
+            },
+            @S_EXT => {
+                warn!("External IRQ should be got from PLIC, not scause");
+                None
+            },
+            @EX_IRQ => IRQ_HANDLER_TABLE.unregister_handler(irq)
+        )
     }
 
     /// Handles the IRQ.
@@ -91,16 +125,23 @@ impl IrqIf for IrqIfImpl {
     fn handle(irq: usize) {
         with_cause!(
             irq,
-            @TIMER => {
+            @S_TIMER => {
                 trace!("IRQ: timer");
-                TIMER_HANDLER();
-            },
-            @EXT => {
-                trace!("IRQ: external");
-                if !IRQ_HANDLER_TABLE.handle(irq) {
-                    warn!("Unhandled IRQ {}", irq);
+                let handler = TIMER_HANDLER.load(Ordering::Acquire);
+                if !handler.is_null() {
+                    // SAFETY: The handler is guaranteed to be a valid function pointer.
+                    unsafe { core::mem::transmute::<*mut (), IrqHandler>(handler)() };
                 }
+            },
+            @S_EXT => {
+                // TODO: get IRQ number from PLIC
+                if !IRQ_HANDLER_TABLE.handle(0) {
+                    warn!("Unhandled IRQ {}", 0);
+                }
+            },
+            @EX_IRQ => {
+                unreachable!("Device-side IRQs should be handled by triggering the External Interrupt.");
             }
-        );
+        )
     }
 }

--- a/platforms/axplat-riscv64-qemu-virt/src/irq.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/irq.rs
@@ -1,0 +1,106 @@
+//! TODO: PLIC
+
+use axplat::irq::{HandlerTable, IrqHandler, IrqIf};
+use lazyinit::LazyInit;
+use riscv::register::sie;
+
+/// Supervisor software interrupt in `scause`
+#[allow(unused)]
+pub(super) const S_SOFT: usize = 1;
+
+/// Supervisor timer interrupt in `scause`
+pub(super) const S_TIMER: usize = 5;
+
+/// Supervisor external interrupt in `scause`
+pub(super) const S_EXT: usize = 9;
+
+static TIMER_HANDLER: LazyInit<IrqHandler> = LazyInit::new();
+
+/// The maximum number of IRQs.
+pub const MAX_IRQ_COUNT: usize = 1024;
+
+static IRQ_HANDLER_TABLE: HandlerTable<MAX_IRQ_COUNT> = HandlerTable::new();
+
+macro_rules! with_cause {
+    ($cause: expr, @TIMER => $timer_op: expr, @EXT => $ext_op: expr $(,)?) => {
+        match $cause {
+            S_TIMER => $timer_op,
+            S_EXT => $ext_op,
+            _ => panic!("invalid trap cause: {:#x}", $cause),
+        }
+    };
+}
+
+pub(super) fn init_percpu() {
+    // enable soft interrupts, timer interrupts, and external interrupts
+    unsafe {
+        sie::set_ssoft();
+        sie::set_stimer();
+        sie::set_sext();
+    }
+}
+
+struct IrqIfImpl;
+
+#[impl_plat_interface]
+impl IrqIf for IrqIfImpl {
+    /// Enables or disables the given IRQ.
+    fn set_enable(irq: usize, _enabled: bool) {
+        if irq == S_EXT {
+            // TODO: set enable in PLIC
+        }
+    }
+
+    /// Registers an IRQ handler for the given IRQ.
+    ///
+    /// It also enables the IRQ if the registration succeeds. It returns `false` if
+    /// the registration failed.
+    fn register(irq: usize, handler: IrqHandler) -> bool {
+        with_cause!(
+            irq,
+            @TIMER => if !TIMER_HANDLER.is_inited() {
+                TIMER_HANDLER.init_once(handler);
+                true
+            } else {
+                false
+            },
+            @EXT => if IRQ_HANDLER_TABLE.register_handler(irq, handler) {
+                Self::set_enable(irq, true);
+                return true;
+            } else {
+                warn!("register handler for IRQ {} failed", irq);
+                false
+            }
+        )
+    }
+
+    /// Unregisters the IRQ handler for the given IRQ.
+    ///
+    /// It also disables the IRQ if the unregistration succeeds. It returns the
+    /// existing handler if it is registered, `None` otherwise.
+    fn unregister(irq: usize) -> Option<IrqHandler> {
+        Self::set_enable(irq, false);
+        IRQ_HANDLER_TABLE.unregister_handler(irq)
+    }
+
+    /// Handles the IRQ.
+    ///
+    /// It is called by the common interrupt handler. It should look up in the
+    /// IRQ handler table and calls the corresponding handler. If necessary, it
+    /// also acknowledges the interrupt controller after handling.
+    fn handle(irq: usize) {
+        with_cause!(
+            irq,
+            @TIMER => {
+                trace!("IRQ: timer");
+                TIMER_HANDLER();
+            },
+            @EXT => {
+                trace!("IRQ: external");
+                if !IRQ_HANDLER_TABLE.handle(irq) {
+                    warn!("Unhandled IRQ {}", irq);
+                }
+            }
+        );
+    }
+}

--- a/platforms/axplat-riscv64-qemu-virt/src/lib.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/lib.rs
@@ -1,0 +1,30 @@
+#![no_std]
+
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate axplat;
+#[macro_use]
+extern crate memory_addr;
+
+mod boot;
+mod console;
+mod init;
+#[cfg(feature = "irq")]
+mod irq;
+mod mem;
+mod power;
+mod time;
+
+mod config {
+    axconfig_gen_macros::include_configs!("axconfig.toml");
+}
+
+unsafe extern "C" fn rust_entry(cpu_id: usize, dtb: usize) {
+    axplat::call_main(cpu_id, dtb);
+}
+
+#[cfg(feature = "smp")]
+unsafe extern "C" fn rust_entry_secondary(cpu_id: usize) {
+    axplat::call_secondary_main(cpu_id);
+}

--- a/platforms/axplat-riscv64-qemu-virt/src/mem.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/mem.rs
@@ -1,0 +1,46 @@
+use axplat::mem::{MemIf, RawRange};
+use memory_addr::{PhysAddr, VirtAddr};
+
+use crate::config::devices::MMIO_RANGES;
+use crate::config::plat::{KERNEL_BASE_PADDR, PHYS_MEMORY_SIZE, PHYS_VIRT_OFFSET};
+
+struct MemIfImpl;
+
+#[allow(dead_code)]
+pub const fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+    va!(paddr.as_usize() + PHYS_VIRT_OFFSET)
+}
+
+#[allow(dead_code)]
+pub const fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+    pa!(vaddr.as_usize() - PHYS_VIRT_OFFSET)
+}
+
+#[impl_plat_interface]
+impl MemIf for MemIfImpl {
+    /// Returns all physical memory (RAM) ranges on the platform.
+    ///
+    /// All memory ranges except reserved ranges (including the kernel loaded
+    /// range) are free for allocation.
+    fn phys_ram_ranges() -> &'static [RawRange] {
+        // TODO: paser dtb to get the available memory ranges
+        // We can't directly use `PHYS_MEMORY_BASE` here, because it may has been used by sbi.
+        &[(KERNEL_BASE_PADDR, PHYS_MEMORY_SIZE)]
+    }
+
+    /// Returns all reserved physical memory ranges on the platform.
+    ///
+    /// Reserved memory can be contained in [`phys_ram_ranges`], they are not
+    /// allocatable but should be mapped to kernel's address space.
+    ///
+    /// Note that the ranges returned should not include the range where the
+    /// kernel is loaded.
+    fn reserved_phys_ram_ranges() -> &'static [RawRange] {
+        &[]
+    }
+
+    /// Returns all device memory (MMIO) ranges on the platform.
+    fn mmio_ranges() -> &'static [RawRange] {
+        &MMIO_RANGES
+    }
+}

--- a/platforms/axplat-riscv64-qemu-virt/src/power.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/power.rs
@@ -1,0 +1,36 @@
+use axplat::power::PowerIf;
+
+struct PowerImpl;
+
+#[impl_plat_interface]
+impl PowerIf for PowerImpl {
+    /// Bootstraps the given CPU core with the given initial stack (in physical
+    /// address).
+    ///
+    /// Where `cpu_id` is the logical CPU ID (0, 1, ..., N-1, N is the number of
+    /// CPU cores on the platform).
+    fn cpu_boot(_cpu_id: usize, _stack_top_paddr: usize) {
+        #[cfg(feature = "smp")]
+        {
+            unsafe extern "C" {
+                fn _start_secondary();
+            }
+            if sbi_rt::probe_extension(sbi_rt::Hsm).is_unavailable() {
+                warn!("HSM SBI extension is not supported for current SEE.");
+                return;
+            }
+            let entry = crate::mem::virt_to_phys(va!(_start_secondary as usize));
+            sbi_rt::hart_start(_cpu_id, entry.as_usize(), _stack_top_paddr);
+        }
+    }
+
+    /// Shutdown the whole system.
+    fn system_off() -> ! {
+        info!("Shutting down...");
+        sbi_rt::system_reset(sbi_rt::Shutdown, sbi_rt::NoReason);
+        warn!("It should shutdown!");
+        loop {
+            axcpu::asm::halt();
+        }
+    }
+}

--- a/platforms/axplat-riscv64-qemu-virt/src/time.rs
+++ b/platforms/axplat-riscv64-qemu-virt/src/time.rs
@@ -1,0 +1,70 @@
+use riscv::register::time;
+
+use axplat::time::TimeIf;
+
+const NANOS_PER_SEC: u64 = 1_000_000_000;
+
+const NANOS_PER_TICK: u64 = NANOS_PER_SEC / crate::config::devices::TIMER_FREQUENCY as u64;
+/// RTC wall time offset in nanoseconds at monotonic time base.
+static mut RTC_EPOCHOFFSET_NANOS: u64 = 0;
+
+pub(super) fn init_early() {
+    #[cfg(feature = "rtc")]
+    use crate::config::devices::RTC_PADDR;
+
+    #[cfg(feature = "rtc")]
+    if RTC_PADDR != 0 {
+        use crate::mem::phys_to_virt;
+        use memory_addr::PhysAddr;
+        use riscv_goldfish::Rtc;
+
+        const GOLDFISH_BASE: PhysAddr = pa!(RTC_PADDR);
+        // Get the current time in microseconds since the epoch (1970-01-01) from the riscv RTC.
+        // Subtract the timer ticks to get the actual time when ArceOS was booted.
+        let epoch_time_nanos =
+            Rtc::new(phys_to_virt(GOLDFISH_BASE).as_usize()).get_unix_timestamp() * 1_000_000_000;
+
+        unsafe {
+            RTC_EPOCHOFFSET_NANOS =
+                epoch_time_nanos - TimeIfImpl::ticks_to_nanos(TimeIfImpl::current_ticks());
+        }
+    }
+}
+
+pub(super) fn init_percpu() {
+    #[cfg(feature = "irq")]
+    sbi_rt::set_timer(0);
+}
+
+struct TimeIfImpl;
+
+#[impl_plat_interface]
+impl TimeIf for TimeIfImpl {
+    /// Returns the current clock time in hardware ticks.
+    fn current_ticks() -> u64 {
+        time::read() as u64
+    }
+
+    /// Converts hardware ticks to nanoseconds.
+    fn ticks_to_nanos(ticks: u64) -> u64 {
+        ticks * NANOS_PER_TICK
+    }
+
+    /// Converts nanoseconds to hardware ticks.
+    fn nanos_to_ticks(nanos: u64) -> u64 {
+        nanos / NANOS_PER_TICK
+    }
+
+    /// Return epoch offset in nanoseconds (wall time offset to monotonic clock start).
+    fn epochoffset_nanos() -> u64 {
+        unsafe { RTC_EPOCHOFFSET_NANOS }
+    }
+
+    /// Set a one-shot timer.
+    ///
+    /// A timer interrupt will be triggered at the specified monotonic time deadline (in nanoseconds).
+    fn set_oneshot_timer(_deadline_ns: u64) {
+        #[cfg(feature = "irq")]
+        sbi_rt::set_timer(Self::nanos_to_ticks(_deadline_ns));
+    }
+}


### PR DESCRIPTION
Add riscv64 and loongarch64 implementations to `axhal_crates`, and have passed the test for the corresponding architectures under ArceOS.