### PR TITLE
[RTC] Support RTC for loongarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "axconfig-gen-macros",
  "axcpu",
  "axplat",
+ "chrono",
  "kspin",
  "lazyinit",
  "log",

--- a/platforms/axplat-aarch64-bsta1000b/src/dw_apb_uart.rs
+++ b/platforms/axplat-aarch64-bsta1000b/src/dw_apb_uart.rs
@@ -2,7 +2,7 @@
 
 use axplat::console::ConsoleIf;
 
-use crate::{config::devices::UART_IRQ, mem::phys_to_virt};
+use crate::mem::phys_to_virt;
 use dw_apb_uart::DW8250;
 use kspin::SpinNoIrq;
 use memory_addr::PhysAddr;
@@ -38,7 +38,7 @@ pub fn init_early() {
 #[cfg(feature = "irq")]
 pub fn init_irq() {
     UART.lock().set_ier(true);
-    axplat_aarch64_common::gic::register_handler(UART_IRQ, handle);
+    axplat_aarch64_common::gic::register_handler(crate::config::devices::UART_IRQ, handle);
 }
 
 /// UART IRQ Handler

--- a/platforms/axplat-aarch64-bsta1000b/src/init.rs
+++ b/platforms/axplat-aarch64-bsta1000b/src/init.rs
@@ -3,7 +3,6 @@ use axplat::init::InitIf;
 #[allow(unused_imports)]
 use crate::config::devices::{GICC_PADDR, GICD_PADDR, TIMER_IRQ};
 use crate::config::plat::PSCI_METHOD;
-use crate::mem::phys_to_virt;
 
 struct InitIfImpl;
 
@@ -34,6 +33,7 @@ impl InitIf for InitIfImpl {
     fn init_later(_cpu_id: usize, _dtb: usize) {
         #[cfg(feature = "irq")]
         {
+            use crate::mem::phys_to_virt;
             axplat_aarch64_common::gic::init_gicd(
                 phys_to_virt(pa!(GICD_PADDR)),
                 phys_to_virt(pa!(GICC_PADDR)),

--- a/platforms/axplat-loongarch64-qemu-virt/Cargo.toml
+++ b/platforms/axplat-loongarch64-qemu-virt/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 [features]
 fp_simd = ["axcpu/fp_simd"]
 irq = []
-rtc = []
+rtc = ["dep:chrono"]
 smp = []
 
 [dependencies]
@@ -22,6 +22,7 @@ memory_addr = "0.3"
 loongArch64 = "0.2.4"
 ns16550a = "0.5.0"
 page_table_entry = "0.5"
+chrono = { version = "0.4", default-features = false, optional = true }
 
 axconfig-gen-macros = { version = "0.1", features = ["nightly"] }
 axcpu = { workspace = true }

--- a/platforms/axplat-loongarch64-qemu-virt/axconfig.toml
+++ b/platforms/axplat-loongarch64-qemu-virt/axconfig.toml
@@ -38,6 +38,7 @@ boot-stack-size = 0x40000                       # uint
 [devices]
 # MMIO ranges with format (`base_paddr`, `size`).
 mmio-ranges = [
+    [0x100D_0000, 0x0000_1000],         # RTC
     [0x100E_0000, 0x0000_1000],         # GED
     [0x1FE0_0000, 0x0000_1000],         # UART
     [0x2000_0000, 0x1000_0000],         # PCI
@@ -79,3 +80,6 @@ uart-paddr = 0x1FE001E0                 # uint
 timer-frequency = 100_000_000           # uint
 # Timer interrupt number.
 timer-irq = 11                          # uint
+
+# RTC (ls7a) Address
+rtc-paddr = 0x100d_0100                 # uint


### PR DESCRIPTION
Initializes the RTC (Real-Time Clock) device.

The QEMU-loongson3-virt platform supports loongson7a RTC device, whose documentation can be found at [Loongson7a RTC](https://github.com/loongson/LoongArch-Documentation/releases/latest/download/Loongson-7A1000-usermanual-v2.00-CN.pdf).

The emulation for RTC in QEMU can be found at [ls7a_rtc.c](https://gitlab.com/qemu-project/qemu/-/blob/1cf9bc6eba7506ab6d9de635f224259225f63466/hw/rtc/ls7a_rtc.c).We will use its TOY counter to provide RTC.

The original implementation can be seen at https://github.com/Mivik/arceos/commit/02d7f4818698080fe599243f7173b6d294f95ffa