### PR TITLE
fix: x86 add .code64 directive for 64-bit code section

### DIFF
--- a/platforms/axplat-x86-pc/src/ap_start.S
+++ b/platforms/axplat-x86-pc/src/ap_start.S
@@ -63,6 +63,7 @@ ap_start32:
     .quad 0x00cf93000000ffff    # 0x18: data segment (base=0, limit=0xfffff, type=32bit data read/write, DPL=0, 4k)
 .Lap_tmp_gdt_end:
 
+.code64
 # 0x7000
 .p2align 12
 .global ap_end


### PR DESCRIPTION
The .code64 directive was not set after the .code32 section, causing the compiler to remain in 32-bit mode. This results in a compilation error when global_asm is used in other crates.