### PR TITLE
fix(x86): correct IO-APIC IRQ routing and console IRQ

### DIFF
--- a/platforms/axplat-x86-pc/src/apic.rs
+++ b/platforms/axplat-x86-pc/src/apic.rs
@@ -69,6 +69,13 @@ fn cpu_has_x2apic() -> bool {
     }
 }
 
+fn current_local_apic_id() -> u8 {
+    match raw_cpuid::CpuId::new().get_feature_info() {
+        Some(finfo) => finfo.initial_local_apic_id(),
+        None => 0,
+    }
+}
+
 pub fn init_primary() {
     info!("Initialize Local APIC...");
 
@@ -106,6 +113,7 @@ pub fn init_primary() {
         use x2apic::ioapic::{IrqMode, RedirectionTableEntry};
 
         let max_entry = io_apic.max_table_entry();
+        let local_apic_id = current_local_apic_id();
         info!(
             "  IO-APIC supports {} IRQ inputs (0-{})",
             max_entry + 1,
@@ -115,7 +123,7 @@ pub fn init_primary() {
         for irq in 0..=max_entry {
             let mut entry = RedirectionTableEntry::default();
             entry.set_vector((IO_APIC_VECTOR_BASE as u8) + irq);
-            entry.set_dest(0);
+            entry.set_dest(local_apic_id);
             entry.set_mode(IrqMode::Fixed);
             if irq >= 10 {
                 entry

--- a/platforms/axplat-x86-pc/src/apic.rs
+++ b/platforms/axplat-x86-pc/src/apic.rs
@@ -29,18 +29,13 @@ static IO_APIC: LazyInit<SpinNoIrq<IoApic>> = LazyInit::new();
 /// Enables or disables the given IRQ.
 #[cfg(feature = "irq")]
 pub fn set_enable(irq: usize, enabled: bool) {
-    let vector = IO_APIC_VECTOR_BASE + irq;
-
-    // LAPIC internal vectors do not go through the IO-APIC.
-    if vector < APIC_TIMER_VECTOR as _ {
-        unsafe {
-            let mut io_apic = IO_APIC.lock();
-            if irq <= io_apic.max_table_entry() as usize {
-                if enabled {
-                    io_apic.enable_irq(irq as u8);
-                } else {
-                    io_apic.disable_irq(irq as u8);
-                }
+    unsafe {
+        let mut io_apic = IO_APIC.lock();
+        if irq <= io_apic.max_table_entry() as usize {
+            if enabled {
+                io_apic.enable_irq(irq as u8);
+            } else {
+                io_apic.disable_irq(irq as u8);
             }
         }
     }
@@ -158,7 +153,12 @@ mod irq_impl {
     impl IrqIf for IrqIfImpl {
         /// Enables or disables the given IRQ.
         fn set_enable(vector: usize, enabled: bool) {
-            super::set_enable(vector, enabled);
+            if vector >= super::APIC_TIMER_VECTOR as usize || vector < super::IO_APIC_VECTOR_BASE {
+                return;
+            }
+
+            let irq = vector - super::IO_APIC_VECTOR_BASE;
+            super::set_enable(irq, enabled);
         }
 
         /// Registers an IRQ handler for the given IRQ.

--- a/platforms/axplat-x86-pc/src/apic.rs
+++ b/platforms/axplat-x86-pc/src/apic.rs
@@ -6,7 +6,7 @@ use axplat::mem::{PhysAddr, pa, phys_to_virt};
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
 use x2apic::{
-    ioapic::IoApic,
+    ioapic::{IoApic, IrqFlags},
     lapic::{LocalApic, LocalApicBuilder, xapic_base},
 };
 use x86_64::instructions::port::Port;
@@ -14,6 +14,7 @@ use x86_64::instructions::port::Port;
 use self::vectors::*;
 
 pub(super) mod vectors {
+    pub const IO_APIC_VECTOR_BASE: usize = 0x20;
     pub const APIC_TIMER_VECTOR: u8 = 0xf0;
     pub const APIC_SPURIOUS_VECTOR: u8 = 0xf1;
     pub const APIC_ERROR_VECTOR: u8 = 0xf2;
@@ -27,14 +28,19 @@ static IO_APIC: LazyInit<SpinNoIrq<IoApic>> = LazyInit::new();
 
 /// Enables or disables the given IRQ.
 #[cfg(feature = "irq")]
-pub fn set_enable(vector: usize, enabled: bool) {
-    // should not affect LAPIC interrupts
+pub fn set_enable(irq: usize, enabled: bool) {
+    let vector = IO_APIC_VECTOR_BASE + irq;
+
+    // LAPIC internal vectors do not go through the IO-APIC.
     if vector < APIC_TIMER_VECTOR as _ {
         unsafe {
-            if enabled {
-                IO_APIC.lock().enable_irq(vector as u8);
-            } else {
-                IO_APIC.lock().disable_irq(vector as u8);
+            let mut io_apic = IO_APIC.lock();
+            if irq <= io_apic.max_table_entry() as usize {
+                if enabled {
+                    io_apic.enable_irq(irq as u8);
+                } else {
+                    io_apic.disable_irq(irq as u8);
+                }
             }
         }
     }
@@ -95,7 +101,32 @@ pub fn init_primary() {
     }
 
     info!("Initialize IO APIC...");
-    let io_apic = unsafe { IoApic::new(phys_to_virt(IO_APIC_BASE).as_usize() as u64) };
+    let mut io_apic = unsafe { IoApic::new(phys_to_virt(IO_APIC_BASE).as_usize() as u64) };
+    unsafe {
+        use x2apic::ioapic::{IrqMode, RedirectionTableEntry};
+
+        let max_entry = io_apic.max_table_entry();
+        info!(
+            "  IO-APIC supports {} IRQ inputs (0-{})",
+            max_entry + 1,
+            max_entry
+        );
+
+        for irq in 0..=max_entry {
+            let mut entry = RedirectionTableEntry::default();
+            entry.set_vector((IO_APIC_VECTOR_BASE as u8) + irq);
+            entry.set_dest(0);
+            entry.set_mode(IrqMode::Fixed);
+            if irq >= 10 {
+                entry
+                    .set_flags(IrqFlags::LEVEL_TRIGGERED | IrqFlags::LOW_ACTIVE | IrqFlags::MASKED);
+            } else {
+                entry.set_flags(IrqFlags::MASKED);
+            }
+            io_apic.set_table_entry(irq, entry);
+        }
+        info!("IO-APIC initialized and masked");
+    }
     IO_APIC.init_once(SpinNoIrq::new(io_apic));
 }
 
@@ -150,12 +181,24 @@ mod irq_impl {
         /// IRQ handler table and calls the corresponding handler. If necessary, it
         /// also acknowledges the interrupt controller after handling.
         fn handle(vector: usize) -> Option<usize> {
-            trace!("IRQ {}", vector);
-            if !IRQ_HANDLER_TABLE.handle(vector) {
-                warn!("Unhandled IRQ {vector}");
+            let irq = if vector >= super::APIC_TIMER_VECTOR as usize {
+                trace!("LAPIC IRQ {}", vector);
+                IRQ_HANDLER_TABLE.handle(vector);
+                unsafe { super::local_apic().end_of_interrupt() };
+                return Some(vector);
+            } else if vector >= super::IO_APIC_VECTOR_BASE {
+                vector - super::IO_APIC_VECTOR_BASE
+            } else {
+                return None;
+            };
+
+            trace!("IRQ {}", irq);
+            if !IRQ_HANDLER_TABLE.handle(irq) {
+                super::set_enable(irq, false);
+                warn!("Unhandled IRQ {irq} (vector {vector})");
             }
             unsafe { super::local_apic().end_of_interrupt() };
-            Some(vector)
+            Some(irq)
         }
 
         /// Sends an inter-processor interrupt (IPI) to the specified target CPU or all CPUs.

--- a/platforms/axplat-x86-pc/src/apic.rs
+++ b/platforms/axplat-x86-pc/src/apic.rs
@@ -191,7 +191,9 @@ mod irq_impl {
         fn handle(vector: usize) -> Option<usize> {
             let irq = if vector >= super::APIC_TIMER_VECTOR as usize {
                 trace!("LAPIC IRQ {}", vector);
-                IRQ_HANDLER_TABLE.handle(vector);
+                if !IRQ_HANDLER_TABLE.handle(vector) {
+                    warn!("Unhandled LAPIC IRQ vector {vector}");
+                }
                 unsafe { super::local_apic().end_of_interrupt() };
                 return Some(vector);
             } else if vector >= super::IO_APIC_VECTOR_BASE {

--- a/platforms/axplat-x86-pc/src/console.rs
+++ b/platforms/axplat-x86-pc/src/console.rs
@@ -42,6 +42,6 @@ impl ConsoleIf for ConsoleIfImpl {
     /// Returns the IRQ number for the console, if applicable.
     #[cfg(feature = "irq")]
     fn irq_num() -> Option<usize> {
-        None
+        Some(4)
     }
 }

--- a/platforms/axplat-x86-pc/src/console.rs
+++ b/platforms/axplat-x86-pc/src/console.rs
@@ -4,6 +4,8 @@ use lazyinit::LazyInit;
 use uart_16550::{Config, Uart16550, backend::PioBackend};
 
 const COM1_PORT: u16 = 0x3F8;
+static COM1: SpinNoIrq<SerialPort> = unsafe { SpinNoIrq::new(SerialPort::new(0x3f8)) };
+const COM1_IRQ: usize = 4;
 
 static UART: LazyInit<SpinNoIrq<Uart16550<PioBackend>>> = LazyInit::new();
 
@@ -42,6 +44,6 @@ impl ConsoleIf for ConsoleIfImpl {
     /// Returns the IRQ number for the console, if applicable.
     #[cfg(feature = "irq")]
     fn irq_num() -> Option<usize> {
-        Some(4)
+        Some(COM1_IRQ)
     }
 }

--- a/platforms/axplat-x86-pc/src/console.rs
+++ b/platforms/axplat-x86-pc/src/console.rs
@@ -4,7 +4,6 @@ use lazyinit::LazyInit;
 use uart_16550::{Config, Uart16550, backend::PioBackend};
 
 const COM1_PORT: u16 = 0x3F8;
-static COM1: SpinNoIrq<SerialPort> = unsafe { SpinNoIrq::new(SerialPort::new(0x3f8)) };
 const COM1_IRQ: usize = 4;
 
 static UART: LazyInit<SpinNoIrq<Uart16550<PioBackend>>> = LazyInit::new();


### PR DESCRIPTION
## Related Issue

https://github.com/Starry-OS/StarryOS/issues/129

On x86_64, a host-side TCP client could not complete a TCP echo exchange with a server running inside the system. The server never reported an accepted connection, the client blocked indefinitely, and the server could not be terminated with `Ctrl+C`. See the issue for full reproduction steps.

## Description

This PR fixes x86 interrupt routing semantics in `axplat-x86-pc` for legacy PCI INTx devices.

The current implementation mixes IO-APIC IRQ lines and CPU interrupt vectors in a few places, which can lead to incorrect IRQ enable/disable behavior and inconsistent interrupt dispatch on x86. It also does not explicitly configure PCI-style legacy INTx entries in the IO-APIC redirection table, and the x86 console IRQ is not reported.

This change aligns the x86 platform interrupt handling with the expected IO-APIC/LAPIC model and makes the console IRQ explicit.

## Implementation

This PR makes the following changes in `axplat-x86-pc`:

- Add `IO_APIC_VECTOR_BASE = 0x20`
  - This makes the external interrupt mapping explicit: IO-APIC IRQ `n` is delivered to CPU vector `0x20 + n`.

- Update `set_enable()`
  - Treat the function input as an IRQ line, not a CPU vector.
  - Use the IRQ line to enable/disable the corresponding IO-APIC entry.

- Initialize IO-APIC redirection table entries in `init_primary()`
  - Set each IRQ entry to vector `IO_APIC_VECTOR_BASE + irq`.
  - Configure IRQs typically used by PCI INTx (`irq >= 10`) as `LEVEL_TRIGGERED | LOW_ACTIVE | MASKED`.
  - Keep all entries masked by default during initialization.

- Update interrupt dispatch in `handle()`
  - Convert external interrupt vectors back to IRQ numbers using `vector - IO_APIC_VECTOR_BASE` before dispatching handlers.
  - Keep LAPIC internal interrupts on the existing direct path.

- Change the unhandled external IRQ path
  - If an IO-APIC interrupt is not handled, mask the IRQ line before sending EOI.
  - This avoids repeated delivery of unacknowledged level-triggered legacy INTx interrupts.

- Set the x86 console IRQ explicitly
  - Return `Some(4)` for the serial console IRQ. (fixing the server could not be terminated with `Ctrl+C`)

The scope of this PR is intentionally limited to legacy IO-APIC / INTx behavior. It does not include MSI-X support or additional polling-specific IRQ handling changes.

## Additional Context

This change follows the same fix direction as the x86 APIC/IRQ handling updates in `x-kernel` commit, but focused on the legacy IO-APIC path in `axplat-x86-pc`.