### PR TITLE
feat(la64): use DMW kernel VA and place _start after image header

### DIFF
--- a/platforms/axplat-loongarch64-qemu-virt/axconfig.toml
+++ b/platforms/axplat-loongarch64-qemu-virt/axconfig.toml
@@ -25,7 +25,7 @@ phys-memory-size = 0x800_0000           # uint
 phys-boot-offset = "0x9000_0000_0000_0000"      # uint
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
-phys-virt-offset = "0xffff_8000_0000_0000"      # uint
+phys-virt-offset = "0x9000_0000_0000_0000"      # uint
 # Offset of bus address and phys address. some boards, the bus address is
 # different from the physical address.
 phys-bus-offset = 0                             # uint
@@ -33,11 +33,11 @@ phys-bus-offset = 0                             # uint
 # Base physical address of the kernel image.
 kernel-base-paddr = 0x0020_0000                 # uint
 # Base virtual address of the kernel image.
-kernel-base-vaddr = "0xffff_8000_0020_0000"     # uint
+kernel-base-vaddr = "0x9000_0000_0020_0000"     # uint
 # Kernel address space base.
-kernel-aspace-base = "0xffff_8000_0000_0000"    # uint
+kernel-aspace-base = "0x9000_0000_0000_0000"    # uint
 # Kernel address space size.
-kernel-aspace-size = "0x0000_7fff_ffff_f000"    # uint
+kernel-aspace-size = "0x0000_ffff_ffff_f000"    # uint
 # Stack size on bootstrapping. (256K)
 boot-stack-size = 0x40000                       # uint
 

--- a/platforms/axplat-loongarch64-qemu-virt/src/boot.rs
+++ b/platforms/axplat-loongarch64-qemu-virt/src/boot.rs
@@ -71,8 +71,10 @@ const BOOT_TO_VIRT: usize = PHYS_VIRT_OFFSET - PHYS_BOOT_OFFSET;
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.boot")]
-unsafe extern "C" fn _start() -> ! {
+unsafe extern "C" fn __boot_start() -> ! {
     core::arch::naked_asm!("
+        .globl  _linux_image_header
+    _linux_image_header:
         .word   0x5a4d              # MZ, MS-DOS header
         .word   0                   # Reserved
         .dword  0x00200040          # Kernel entry point
@@ -83,6 +85,9 @@ unsafe extern "C" fn _start() -> ! {
         .dword  0                   # Reserved
         .word   0x818223cd          # Magic number
         .word   0x0                 # Offset to the PE header
+
+        .globl  _start
+    _start:
 
         # Setup DMW
         li.d        $t0, {phys_boot_offset} | 0x11


### PR DESCRIPTION
This pr aims at passing ELF to qemu directly without stripping the ELF file.
Switch the LoongArch QEMU-virt default kernel virtual layout to a DMW-friendly 0x9000_... range and separate the Linux image header label from the real `_start` entry in boot code. This avoids direct `-kernel` ELF boot hangs seen with the previous high-half `0xffff_8000_...` layout on current QEMU LoongArch boot path.